### PR TITLE
Refactor: Simplified `recordMeshData`

### DIFF
--- a/engine/src/core/Engine.cpp
+++ b/engine/src/core/Engine.cpp
@@ -231,7 +231,7 @@ namespace kailux
             recorder.setViewport(m_Swapchain.getExtent());
             recorder.setScissor(m_Swapchain.getExtent());
 
-            recordMeshData(frame, recorder, m_MeshRegistry.getMeshCount());
+            recordMeshData(frame, recorder);
 
             recorder.endRendering();
 
@@ -292,7 +292,7 @@ namespace kailux
         return commands;
     }
 
-    void Engine::recordMeshData(const FrameData &frame, const CommandRecorder &recorder, uint32_t meshCount) const
+    void Engine::recordMeshData(const FrameData &frame, const CommandRecorder &recorder) const
     {
         m_Pipeline.bind(recorder.getCommandBuffer());
         m_MeshRegistry.bind(recorder.getCommandBuffer());
@@ -300,7 +300,7 @@ namespace kailux
 
         recorder.drawIndexedIndirect(
             frame.getIndirectBuffer(),
-            meshCount
+            m_MeshRegistry.getMeshCount()
         );
     }
 

--- a/engine/src/core/Engine.h
+++ b/engine/src/core/Engine.h
@@ -74,7 +74,7 @@ namespace kailux
         void                                        submit(const FrameData& frame, vk::Semaphore imageAvailableSemaphore, vk::Semaphore renderFinishedSemaphore) const;
         void                                        render(Window &window);
         std::vector<vk::DrawIndexedIndirectCommand> getMeshIndirectCommands() const;
-        void                                        recordMeshData(const FrameData &frame, const CommandRecorder &recorder, uint32_t meshCount) const;
+        void                                        recordMeshData(const FrameData &frame, const CommandRecorder &recorder) const;
         void                                        recordImGuiData(const FrameData& frame);
 
         void updateFrameBuffers(FrameData& frame, const CommandRecorder& recorder) const;


### PR DESCRIPTION
Simplified `recordMeshData` by removing redundant `meshCount` parameter